### PR TITLE
Make range of commits clearer

### DIFF
--- a/script.js
+++ b/script.js
@@ -149,9 +149,63 @@ function addCheckboxes() {
 		checkbox = document.createElement('input');
 		checkbox.type = 'checkbox';
 		checkbox.value = sha;
+		checkbox.onclick = highlightRange;
 		checkbox.className = 'commit-compare-checkbox';
 		
 		listItem.appendChild(checkbox);
+
+		function highlightRange() {
+			var allCheckboxes = getAllCheckboxElements(),
+				selectedCheckboxes = getSelectedCheckboxes(allCheckboxes),
+				foundFirstSelectedCheckbox = false,
+				foundSecondSelectedCheckbox = false;
+				
+			if(selectedCheckboxes.length < 2) {
+				enableAllCheckboxes();
+				return;
+			}
+			
+			allCheckboxes.forEach(disableBasedOnSelection);
+			
+			function disableBasedOnSelection(checkbox) {
+				if(!foundFirstSelectedCheckbox) {
+					disableUntilFirstCheckboxFound(checkbox);
+				} 
+				
+				if(!foundSecondSelectedCheckbox) {
+					verifyIsSecondSelected(checkbox);
+				} else {
+					disableAndUncheckAfterSecondCheckboxFound(checkbox);
+				}
+			}
+			
+			function disableAndUncheckAfterSecondCheckboxFound(checkbox) {
+				checkbox.disabled = true;
+				checkbox.checked = false;
+			}
+			
+			function disableUntilFirstCheckboxFound(checkbox) {
+				if(checkbox.value !== selectedCheckboxes[0].value) {
+					checkbox.disabled = true;
+				} else {
+					foundFirstSelectedCheckbox = true;
+				}
+			}
+			
+			function verifyIsSecondSelected(checkbox) {
+				if(checkbox.value === selectedCheckboxes[1].value) {
+					foundSecondSelectedCheckbox = true;
+				}
+			}
+			
+			function enableAllCheckboxes() {
+				allCheckboxes.forEach(disableIt);
+				
+				function disableIt(checkbox) {
+					checkbox.disabled = false;
+				}
+			}
+		}
 	}
 }
 

--- a/script.js
+++ b/script.js
@@ -43,27 +43,10 @@ function addGenerateCompareUrlButton() {
 		var checkboxes,
 			selectedCheckboxes,
 			firstSelectedCommitSHA,
-			secondSelectedCommitSHA,
-			lastIndexOfSelectedCheckboxes;
+			secondSelectedCommitSHA;
 			
-		checkboxes = commitListItems.map(toCheckboxes);
-		
-		function toCheckboxes(listItem) {
-			return listItem.getElementsByClassName('commit-compare-checkbox')[0];
-		}
-				
-		selectedCheckboxes = checkboxes
-							.filter(onSelectedCheckboxes);
-				
-		function onSelectedCheckboxes(checkbox, index) {
-			var checkboxIsChecked = checkbox.checked;
-			
-			if(checkboxIsChecked) {
-				lastIndexOfSelectedCheckboxes = index;
-			}
-			
-			return checkboxIsChecked;
-		}
+		checkboxes = getAllCheckboxElements();
+		selectedCheckboxes = getSelectedCheckboxes(checkboxes);
 			
 		if(selectedCheckboxes.length === 0) {
 			showNotification('error', 'You have not selected any commits!');
@@ -81,7 +64,7 @@ function addGenerateCompareUrlButton() {
 		}
 		
 		firstSelectedCommitSHA = selectedCheckboxes[0].value;
-		secondSelectedCommitSHA = checkboxes[lastIndexOfSelectedCheckboxes + 1].value;
+		secondSelectedCommitSHA = selectedCheckboxes[1].value;
 		
 		if(!firstSelectedCommitSHA || !secondSelectedCommitSHA) {
 			showNotification('error', 'Could not find commits SHAs.');
@@ -123,6 +106,25 @@ function addGenerateCompareUrlButton() {
 		}
 	}
 }
+
+function getAllCheckboxElements() {
+	return commitListItems.map(toCheckboxes);
+
+	function toCheckboxes(listItem) {
+		return listItem.getElementsByClassName('commit-compare-checkbox')[0];
+	}
+}
+
+function getSelectedCheckboxes(checkboxes) {
+	return checkboxes.filter(onSelectedCheckboxes);
+				
+	function onSelectedCheckboxes(checkbox) {
+		var checkboxIsChecked = checkbox.checked;
+		
+		return checkboxIsChecked;
+	}
+}
+
 
 function addNotificationContainer() {
 	var fileNavigationElement;

--- a/script.js
+++ b/script.js
@@ -96,7 +96,8 @@ function addGenerateCompareUrlButton() {
 		function baseCompareUrlFromCurrentCommitsUrl() {
 			var indexOfCommitsPartOfUrl,
 				githubCommitsUrl,
-				githubCompareUrlLastPart
+				githubCommitsUrlFirstPart,
+				githubCompareUrlLastPart;
 				
 			githubCompareUrlLastPart = 'compare/' + secondSelectedCommitSHA + '...' + firstSelectedCommitSHA;
 			

--- a/script.js
+++ b/script.js
@@ -199,9 +199,9 @@ function addCheckboxes() {
 			}
 			
 			function enableAllCheckboxes() {
-				allCheckboxes.forEach(disableIt);
+				allCheckboxes.forEach(enableIt);
 				
-				function disableIt(checkbox) {
+				function enableIt(checkbox) {
 					checkbox.disabled = false;
 				}
 			}


### PR DESCRIPTION
This PR aims to make the selection of commits clearer. I did so by disabling the checkboxes "outside" of the selection. 

It could possibly be better to instead use CSS to in some way just highlight the range but I feel that this is still a step forward. One could possibly build upon this solution to improve it further.
- Clicking one checkbox has intentionally no effect since you might want to start your range either from the beginning or the end
- Clicking a second checkbox will disable the checkboxes up until the first selected one, and the ones after the second selected one
- Clicking a checkbox in between a range will make a new range by excluding the previously selected _second_ one

See recording here:
http://recordit.co/p4homOMJOb
