### PR TITLE
fix an issue where the UI doesn't work

### DIFF
--- a/script.js
+++ b/script.js
@@ -16,7 +16,7 @@ function drawElements() {
 	}
 
 	const buttonDestination = document.getElementsByClassName(buttonDestinationClass)[0];
-	commitListItems = Array.from(document.getElementsByClassName('commit'));
+	commitListItems = Array.from(document.getElementsByClassName('js-commits-list-item'));
 
 	addGenerateCompareUrlButton(buttonDestination);
 	addCheckboxes();
@@ -116,12 +116,11 @@ function getSelectedCheckboxes(checkboxes) {
 
 function addCheckboxes() {
 	commitListItems.forEach(appendCheckbox);
-
 	function appendCheckbox(listItem) {
 		let sha,
 			checkbox;
 
-		sha = listItem.getElementsByClassName('sha')[0].text.trim();
+		sha = listItem.getAttribute('data-url').match(/[\da-f]{40}/);
 
 		checkbox = document.createElement('input');
 		checkbox.type = 'checkbox';

--- a/styles.css
+++ b/styles.css
@@ -18,13 +18,15 @@
 	-ms-user-select: none;
 	user-select: none;
 	-webkit-appearance: none;
+	z-index: 9999;
 }
 
 .commit-compare-checkbox {
 	position: absolute;
-	left: 0;
+	left: -42px;
 	margin-top: 21px;
 	margin-left: 21px;
+	z-index: 9999;
 }
 
 .table-list {


### PR DESCRIPTION
It seems that the layout of GitHub website has changed, so that this extension failed to get the values of commit SHAs and the checkboxes and 'Generate compare url' button hasn't worked.